### PR TITLE
Fixes plugin organization links

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,8 +10,8 @@ description = "Prevent ProcessTreeKiller from reaping Gradle daemons"
 jenkinsPlugin {
     coreVersion = "2.11"
     displayName = "Gradle Daemon saver"
-    url = "https://github.com/gradle-community/jenkins-gradle-daemon"
-    gitHubUrl = "https://github.com/gradle-community/jenkins-gradle-daemon"
+    url = "https://github.com/jenkinsci/jenkins-gradle-daemon"
+    gitHubUrl = "https://github.com/jenkinsci/jenkins-gradle-daemon"
     shortName = "gradle-daemon"
 
     developers {


### PR DESCRIPTION
The plugin was migrated to jenkinsci organization.

This will ensure that the link generated by the update-center are correct and plugins.jenkins.io/gradle-daemon has the correct metadata.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
