### PR TITLE
Update Jenkinsfile syntax

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin()
+buildPluginWithGradle(useContainerAgent: true)


### PR DESCRIPTION
The buildPlugin syntax is reserved for plugins using maven, and deprecated for plugins using gradle to build.
The change proposed updates the syntax to use the proper buildPluginWithGradle build step.